### PR TITLE
Fixes U/P Env Vars and updates s6-overlay method

### DIFF
--- a/goodsync/Dockerfile
+++ b/goodsync/Dockerfile
@@ -7,7 +7,6 @@ ENV DIRECTORY_CONFIG=/config \
 
 ADD https://www.goodsync.com/download/goodsync-release-${ARCH}.tar.gz /tmp/goodsync-release-${ARCH}.tar.gz
 
-ADD root/ /
 
 RUN echo "**** install gs-server ****" && \
  tar xvzf /tmp/goodsync-release-${ARCH}.tar.gz -C /usr/bin --strip-components=1 && \
@@ -15,8 +14,7 @@ RUN echo "**** install gs-server ****" && \
  echo "**** cleanup ****" && \
  rm -rf /tmp/*
 
- RUN echo "**** set extra permissions ****" && \
-    chmod +x /etc/services.d/goodsync/run
+ADD root/ /
 
 # [PORTS]
 # WebUI Port

--- a/goodsync/root/etc/s6-overlay/s6-rc.d/goodsync/finish
+++ b/goodsync/root/etc/s6-overlay/s6-rc.d/goodsync/finish
@@ -1,0 +1,3 @@
+#!/command/execlineb -S1
+if { s6-test ${1} -ne 0 -a ${1} -ne 256 }
+/run/s6/basedir/bin/halt

--- a/goodsync/root/etc/s6-overlay/s6-rc.d/goodsync/run
+++ b/goodsync/root/etc/s6-overlay/s6-rc.d/goodsync/run
@@ -9,6 +9,9 @@ else
         if [ -z "${GS_USERNAME}" ] || [ -z "${GS_PASSWORD}" ]; then
             echo "Admin username and password must be set"
             exit 1
+        else
+            ADMIN_USERNAME=${GS_USERNAME}
+            ADMIN_PASSWORD=${GS_PASSWORD}
         fi
     else
         echo "Setting admin username and password ${GS_USER_SECRET}"
@@ -16,14 +19,11 @@ else
         ADMIN_PASSWORD=$(cat /run/secrets/${GS_PASS_SECRET})
     fi
     echo "Initializing config"
-    /usr/bin/gs-server /profile=${DIRECTORY_CONFIG:=/config} /set-admin="${ADMIN_USERNAME}:${ADMIN_PASSWORD}" /console &
-    PID=$!
-    sleep 10
-    kill $PID
+    /usr/bin/gs-server /profile=${DIRECTORY_CONFIG:=/config} /set-admin="${ADMIN_USERNAME}:${ADMIN_PASSWORD}" /console
     # Enable remote access
     sed -i 's/WebUiLocalOnly = Yes/WebUiLocalOnly = No/' /config/settings.tix
     touch /config/.initialized
-    sleep 30
+    sleep 15
 fi
 
 /usr/bin/gs-server /profile=${DIRECTORY_CONFIG:=/config} /console

--- a/goodsync/root/etc/s6-overlay/s6-rc.d/goodsync/type
+++ b/goodsync/root/etc/s6-overlay/s6-rc.d/goodsync/type
@@ -1,0 +1,1 @@
+longrun


### PR DESCRIPTION
(PATCH)
This fixes an issue with GS_USERNAME and GS_PASSWORD not working.

This also removes the need for permission fixing by using the non-legacy s6-overlay directories.